### PR TITLE
Version numbering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,7 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+# =========================
+# Version number file
+Version.txt

--- a/src/IonFar.SharePoint.Migration.sln
+++ b/src/IonFar.SharePoint.Migration.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IonFar.SharePoint.Migration", "IonFar.SharePoint.Migration\IonFar.SharePoint.Migration.csproj", "{00B17940-1B52-4A22-933E-A00C37A48093}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication", "TestApplication\TestApplication.csproj", "{48E143F9-8304-4A37-BB3F-ED1848771DF2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C0998076-31A7-4E99-9AA8-DDAEB3CF1A54}"
+	ProjectSection(SolutionItems) = preProject
+		TFSBuildNumber.targets = TFSBuildNumber.targets
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/IonFar.SharePoint.Migration/IonFar.SharePoint.Migration.csproj
+++ b/src/IonFar.SharePoint.Migration/IonFar.SharePoint.Migration.csproj
@@ -71,4 +71,14 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <PropertyGroup>
+    <TFSBaseBuildYear>2015</TFSBaseBuildYear>
+  </PropertyGroup>
+  <Import Project="..\TFSBuildNumber.targets"/>
+  <Target Name="BeforeBuild"
+     DependsOnTargets="GetMajorMinorFromCSharpAssemblyInfoFile;WriteProjectTextAssemblyVersionFile;UpdateCSharpAssemblyInfoFile">
+  </Target>
+  <Target Name="AfterBuild"
+     DependsOnTargets="ResetCSharpAssemblyInfoFile">
+  </Target>
 </Project>

--- a/src/IonFar.SharePoint.Migration/Migrator.cs
+++ b/src/IonFar.SharePoint.Migration/Migrator.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using IonFar.SharePoint.Migration.Infrastructure;
 using Microsoft.SharePoint.Client;
 using Newtonsoft.Json;
+using System.Diagnostics;
 
 namespace IonFar.SharePoint.Migration
 {
@@ -39,6 +40,10 @@ namespace IonFar.SharePoint.Migration
         {
             try
             {
+                var assembly = Assembly.GetExecutingAssembly();
+                var fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+                _logger.Information("IonFar.SharePoint.Migrator v" + fvi.FileVersion);
+
                 LogInfo("Starting upgrade against SharePoint instance at " + _clientContext.Url);
                 var availableMigrations = GetAvailableMigrations(assemblyContainingMigrations, filter);
                 var appliedMigrations = GetAppliedMigrations();

--- a/src/IonFar.SharePoint.Migration/Properties/AssemblyInfo.cs
+++ b/src/IonFar.SharePoint.Migration/Properties/AssemblyInfo.cs
@@ -33,3 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/src/IonFar.SharePoint.Migration/Properties/AssemblyInfo.cs
+++ b/src/IonFar.SharePoint.Migration/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IonFar.SharePoint.Migration")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Library that helps you to deploy and manage changes to a SharePoint Site collection using the client side object model (CSOM). Changes are recorded once run in a SharePoint environment so that only changes that need to be run will be applied.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("IonFar.SharePoint.Migration")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © Jack Watts 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/IonFar.SharePoint.Migration/Properties/AssemblyInfo.cs
+++ b/src/IonFar.SharePoint.Migration/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -21,3 +21,15 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("4f643f6d-aec9-42f4-94dd-d033f074088c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/TFSBuildNumber.targets
+++ b/src/TFSBuildNumber.targets
@@ -1,0 +1,382 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0"
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- TFSBuildNumber.targets, Version 1.3 - August, 2014 -->
+
+  <!-- Updates build numbers in projects based on the TFS build number.
+  
+       Supports:
+         - Extracting the major/minor versions from C# version attributes in an 
+           existing file (defaults to Properties\AssemblyInfo.cs).
+         - Updating C# version attributes in the info file.
+         - Writing build number into a plain Version.txt file in the project root
+           (e.g. for copying to output as content along with web site files)
+         - Reset the AssemblyInfo.cs file after the build (so it isn't
+           constantly being updated in version control, including TFS 2012
+           local workspaces).
+         - If assembly info file needs to be Read Only (so that older TFS source
+           control doesn't pick it up as a change) then can unset/set the
+           read only flag on the file.
+           
+       To use:
+       
+       1. Include TFSBuildNumber.targets in your solution, probably in
+          a shared location.
+          
+       2. Edit .csproj files to Import the TFSBuildNumber.targets project.
+       
+       3. Add BeforeBuild target to the .csproj, with a dependency on
+          the GetMajorMinorFromCSharpAssemblyInfoFile task to get the major/minor
+          numbers, and then UpdateCSharpAssemblyInfoFile to generate the
+          build number (build and revision parts) and update the file.
+          
+          You can also add a dependency on WriteProjectTextAssemblyVersionFile 
+          to generate a text file.
+          
+          If you want to use a file other than the default (Properties/AssemblyInfo.cs),
+          then set the <VersionInfoFile> property.
+          
+       4. Add AfterBuild target with a dependency on ResetCSharpAssemblyInfoFile
+          to reset the changes (if you don't want to check in changes to AssemblyInfo.cs
+          after every local build).
+          
+       5. Set the TFSBaseBuild property in the .csproj file (defaults to 2010).
+          By setting the base year you will have nicely increasing version
+          numbers.
+          
+          You can update the base year whenever you change the major or
+          minor version number.
+          
+       6. If your AssemblyInfo.cs file is usually read only, then you need to set
+          the additional property <TFSSetReadOnly>true</TFSSetReadOnly> to handle this.
+          
+       NOTE: If you don't want to use GetMajorMinorFromCSharpAssemblyInfoFile,
+       an alternative is to set the TFSMajorBuildNumber and TFSMinorBuildNumber
+       properties in your .csproj file.
+       
+       Example to insert in your .csproj file (change TFSBaseBuildYear as desired):
+       
+       <PropertyGroup>
+         <TFSBaseBuildYear>2010</TFSBaseBuildYear>
+       </PropertyGroup>
+       <Import Project="TFSBuildNumber.targets"/>
+       <Target Name="BeforeBuild"
+          DependsOnTargets="GetMajorMinorFromCSharpAssemblyInfoFile;WriteProjectTextAssemblyVersionFile;UpdateCSharpAssemblyInfoFile">
+       </Target>
+       <Target Name="AfterBuild"
+          DependsOnTargets="ResetCSharpAssemblyInfoFile">
+       </Target>
+
+       Additional optional properties that can be used:
+
+       <PropertyGroup>
+         <VersionInfoFile>$(MSBuildProjectDirectory)\VersionInfo.cs</VersionInfoFile>
+         <TFSMajorBuildNumber>1</TFSMajorBuildNumber>
+         <TFSMinorBuildNumber>0</TFSMinorBuildNumber>
+         <TFSSetReadOnly>true</TFSSetReadOnly>
+       </PropertyGroup>
+
+       -->
+
+       <!-- Based on original work in Wintellect.TFSBuildNumber.Targets 
+       by John Robbins (john@wintellect.com).
+       
+       From the original description:
+       
+       "A set of pure MSBuild 4.0 tasks that generate build version information 
+       for a TFS 2010 Team Build in order to have your file versions match 
+       exactly the TFS build numbers. Everything is in this file, you don't 
+       need to install any other DLLs, assemblies, or magic on your TFS build 
+       server. MSBuild 4.0 really is quite wonderful!"
+       -->
+
+  <PropertyGroup>
+    <!-- Figure out where the TFS build tasks are. -->
+    <TeamBuildRefPath Condition="'$(TeamBuildRefPath)'==''">$(VS100COMNTOOLS)..\IDE\PrivateAssemblies\</TeamBuildRefPath>
+    <!-- Figure out where I'm being called from, TFS Build or a developer 
+         machine. BuildUri and TeamFoundationServerUrl properties are the 
+         ones that tell me I'm running under TFS Build.-->
+    <WintellectBuildType>DEVELOPERBUILD</WintellectBuildType>
+    <WintellectBuildType Condition="'$(BuildUri)'!='' and '$(TeamFoundationServerUrl)'!=''">TFSBUILD</WintellectBuildType>
+  </PropertyGroup>
+
+  <!-- Set up the dependency on the InitializeBuildProperties task only 
+       if running under TFS Build. -->
+  <PropertyGroup Condition="'$(WintellectBuildType)'=='TFSBUILD'">
+    <DependOnGetBuildProperties>GetBuildProperties</DependOnGetBuildProperties>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <VersionInfoFile Condition="'$(VersionInfoFile)'==''">$(MSBuildProjectDirectory)\Properties\AssemblyInfo.cs</VersionInfoFile>
+    <TFSBaseBuildYear Condition="'$(TFSBaseBuildYear)'==''">2010</TFSBaseBuildYear>
+  </PropertyGroup>
+  
+  <!-- Use the GetBuildProperties task -->  
+  <UsingTask TaskName="Microsoft.TeamFoundation.Build.Tasks.GetBuildProperties"
+         AssemblyFile="$(TeamBuildRefPath)\Microsoft.TeamFoundation.Build.ProcessComponents.dll" />
+
+  <Target Name="GetBuildProperties">
+    <GetBuildProperties TeamFoundationServerUrl="$(TeamFoundationServerUrl)"
+                        BuildUri="$(BuildUri)" >
+      <!-- Outputs are the initial values for the various properties of the build. -->
+      <Output TaskParameter="BuildDefinitionName" PropertyName="BuildDefinitionName" />
+      <Output TaskParameter="BuildDefinitionUri" PropertyName="BuildDefinitionUri" />
+      <Output TaskParameter="BuildNumber" PropertyName="BuildNumber" />
+    </GetBuildProperties>
+    <Message Text="Build definition '$(BuildDefinitionName)', number '$(BuildNumber)', uri '$(BuildDefinitionUri)'." />
+  </Target>
+
+  <!-- The TFSBuildFileVersion target builds the string suitable for using to 
+       generate an acceptable AssemblyFileVersion attribute with the exact
+       build being done by TFS Build 2010.
+       
+       This assumes a format of $(BuildDefinitionName)_$(Date:yyyyMMdd)$(Rev:.r) 
+       for the build number format. Tweak if you are using a different format.
+       
+       For the code below, the $(BuildNumber) property from TFS Build 2010 will 
+       look like: Dev Branch Daily Build_20091107.14
+       The important properties output of this task are those that start with 
+       TFS and are shown below.
+       (Property)                 (Example Value)
+       TFSFullBuildVersionString  3.1.21107.14
+       TFSBuildNumber             21107
+       TFSCalculatedYear          2
+       TFSBuildYear               2009
+       TFSBuildMonth              11
+       TFSBuildDay                07
+       TFSBuildRevision           14
+       -->
+  <Target Name="TFSBuildFileVersion"
+          DependsOnTargets="$(DependOnGetBuildProperties)">
+
+    <!-- Do the error checking to ensure the appropriate items are defined.-->
+    <Error Condition="'$(TFSMajorBuildNumber)'==''"
+           Text="TFSMajorBuildNumber is not defined."/>
+    <Error Condition="'$(TFSMinorBuildNumber)'==''"
+           Text="TFSMinorBuildNumber is not defined."/>
+
+    <PropertyGroup>
+      <!-- The separator string between the $(BuildDefinition) and the date 
+           revision.-->
+      <BuildDefSeparatorValue>_</BuildDefSeparatorValue>
+      <!-- The separator between the date and revision.-->
+      <DateVerSeparatorValue>.</DateVerSeparatorValue>
+    </PropertyGroup>
+
+    <!-- The calculations when run on a TFS Build Server.-->
+    <PropertyGroup Condition="'$(WintellectBuildType)'=='TFSBUILD'">
+      <!-- Get where the timestamp starts-->
+      <tmpStartPosition>$([MSBuild]::Add($(BuildDefinitionName.Length), $(BuildDefSeparatorValue.Length)))</tmpStartPosition>
+      <!-- Get the date and version portion. ex: 20091107.14-->
+      <tmpFullDateAndVersion>$(BuildNumber.Substring($(tmpStartPosition)))</tmpFullDateAndVersion>
+      <!-- Find the position where the date and version separator splits 
+           the string. -->
+      <tmpDateVerSepPos>$(tmpFullDateAndVersion.IndexOf($(DateVerSeparatorValue)))</tmpDateVerSepPos>
+      <!-- Grab the date. ex: 20081107-->
+      <tmpFullBuildDate>$(tmpFullDateAndVersion.SubString(0,$(tmpDateVerSepPos)))</tmpFullBuildDate>
+      <!-- Bump past the separator. -->
+      <tmpVerStartPos>$([MSBuild]::Add($(tmpDateVerSepPos),1))</tmpVerStartPos>
+      <!-- Get the revision string. ex: 14-->
+      <TFSBuildRevision>$(tmpFullDateAndVersion.SubString($(tmpVerStartPos)))</TFSBuildRevision>
+      <!-- Get the pieces so if someone wants to customize, they have them.-->
+      <TFSBuildYear>$(tmpFullBuildDate.SubString(0,4))</TFSBuildYear>
+      <TFSBuildMonth>$(tmpFullBuildDate.SubString(4,2))</TFSBuildMonth>
+      <TFSBuildDay>$(tmpFullBuildDate.SubString(6,2))</TFSBuildDay>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(WintellectBuildType)'=='DEVELOPERBUILD'">
+      <TFSBuildRevision>0</TFSBuildRevision>
+      <TFSBuildYear>$([System.DateTime]::Now.Year.ToString("0000"))</TFSBuildYear>
+      <TFSBuildMonth>$([System.DateTime]::Now.Month.ToString("00"))</TFSBuildMonth>
+      <TFSBuildDay>$([System.DateTime]::Now.Day.ToString("00"))</TFSBuildDay>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <!-- This is the Excel calculation "=MOD(year-2001,6)"-->
+      <!-- That's what it looks like DevDiv is using for their calculations. -->
+      <TFSCalculatedYear>$([MSBuild]::Subtract($(TFSBuildYear),$(TFSBaseBuildYear)))</TFSCalculatedYear>
+
+      <tmpBuildNumber>$(TFSCalculatedYear)$(TFSBuildMonth)$(TFSBuildDay)</tmpBuildNumber>
+      <TFSBuildNumber>$(tmpBuildNumber.TrimStart('0'))</TFSBuildNumber>
+      <TFSFullBuildVersionString>$(TFSMajorBuildNumber).$(TFSMinorBuildNumber).$(TFSBuildNumber).$(TFSBuildRevision)</TFSFullBuildVersionString>
+    </PropertyGroup>
+
+    <Message Text="TFS Build Version $(TFSFullBuildVersionString) (build type $(WintellectBuildType))." />
+
+    <!-- Do some error checking as empty properties screw up everything.-->
+    <Error Condition="'$(TFSFullBuildVersionString)'==''"
+           Text="Error building the TFSFullBuildVersionString property"/>
+    <Error Condition="'$(TFSBuildNumber)'==''"
+           Text="Error building the TFSBuildNumber property"/>
+    <Error Condition="'$(TFSCalculatedYear)'==''"
+           Text="Error building the TFSCalculatedYear property"/>
+    <Error Condition="'$(TFSBuildDay)'==''"
+           Text="Error building the TFSBuildDay property"/>
+    <Error Condition="'$(TFSBuildMonth)'==''"
+           Text="Error building the TFSBuildMonth property"/>
+    <Error Condition="'$(TFSBuildYear)'==''"
+           Text="Error building the TFSBuildYear property"/>
+    <Error Condition="'$(TFSBuildRevision)'==''"
+           Text="Error building the TFSBuildRevision property"/>
+  </Target>
+
+  <!-- This extracts the major/minor version from an existing 
+     C-Sharp AssemblyInfo.cs file.
+	 
+	 This means that rather than specifying major/minor in the
+	 .CSPROJ build file, all you need to do is add a before build
+	 dependency to this target, plus the update target.
+   -->
+
+  <Target Name="GetMajorMinorFromCSharpAssemblyInfoFile">
+    <CreateProperty Value='$(VersionInfoFile)'>
+      <Output TaskParameter="Value" PropertyName="SourceAssemblyInfoFile" />
+    </CreateProperty>
+    <Message Text="Reading version number from file $(SourceAssemblyInfoFile)." />
+    <CreateProperty	Value='$([System.IO.File]::ReadAllText("$(SourceAssemblyInfoFile)"))'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="OriginalAssemblyInfo" />
+    </CreateProperty>
+    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Match($(OriginalAssemblyInfo),"AssemblyFileVersion\s*\(\s*(.*?)\s*\)").Groups[1].Value)'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="AssemblyFileVersion" />
+    </CreateProperty>
+    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Match($(AssemblyFileVersion),"^.(\d+)\.(\d+)\..*$").Groups[1].Value)'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="TFSMajorBuildNumber" />
+    </CreateProperty>
+    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Match($(AssemblyFileVersion),"^.(\d+)\.(\d+)\..*$").Groups[2].Value)'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="TFSMinorBuildNumber" />
+    </CreateProperty>
+    <Message Text="Found version $(TFSMajorBuildNumber).$(TFSMinorBuildNumber)." />
+  </Target>
+
+  <!-- This target updates an existing C-Sharp AssemblyInfo.cs file.
+	 
+	 This means that rather than having to modify projects and
+	 link a central SharedAssemblyInfo.cs file, you can simply
+	 add a before build dependency to the update target and
+	 the existing file will be updated.
+	 
+	 Note that the file is also changed back to read-only after
+	 updating, so that it is not picked up as a changed file.
+   -->
+
+  <Target Name="UpdateCSharpAssemblyInfoFile"
+          DependsOnTargets="TFSBuildFileVersion" >
+    <CreateProperty Value='$(VersionInfoFile)'>
+      <Output TaskParameter="Value" PropertyName="SourceAssemblyInfoFile" />
+    </CreateProperty>
+    <CreateProperty Value='$(SourceAssemblyInfoFile)'>
+      <Output TaskParameter="Value" PropertyName="DestinationAssemblyInfoFile" />
+    </CreateProperty>
+    <CreateProperty Value='"$(TFSFullBuildVersionString)"'>
+      <Output TaskParameter="Value" PropertyName="AssemblyFileVersion" />
+    </CreateProperty>
+    <CreateProperty Value='"$(TFSMajorBuildNumber).$(TFSMinorBuildNumber).0.0"'>
+      <Output TaskParameter="Value" PropertyName="AssemblyVersion" />
+    </CreateProperty>
+    <Exec Condition="Exists('$(DestinationAssemblyInfoFile)') and '$(TFSSetReadOnly)'=='true'" Command='attrib -R "$(DestinationAssemblyInfoFile)"' IgnoreExitCode='true' />
+    <Message Text="Updating file '$(DestinationAssemblyInfoFile)' with file version $(AssemblyFileVersion)." />
+    <CreateProperty	Value='$([System.IO.File]::ReadAllText("$(SourceAssemblyInfoFile)"))'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="OriginalAssemblyInfo" />
+    </CreateProperty>
+    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Replace($(OriginalAssemblyInfo),"AssemblyFileVersion\s*\(.*?\)","AssemblyFileVersion($(AssemblyFileVersion))"))'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="FileVersionUpdatedInfo" />
+    </CreateProperty>
+    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Replace($(FileVersionUpdatedInfo),"AssemblyVersion\s*\(.*?\)","AssemblyVersion($(AssemblyVersion))"))'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="FullUpdatedInfo" />
+    </CreateProperty>
+    <WriteLinesToFile
+      File="$(DestinationAssemblyInfoFile)"
+      Lines='$(FullUpdatedInfo)'
+      Overwrite="true" />
+    <Exec Condition="'$(TFSSetReadOnly)'=='true'" Command='attrib +R "$(DestinationAssemblyInfoFile)"' />
+  </Target>
+
+  <!-- This resets the build and release numbers in AssemblyInfo.cs.
+	 
+   With local file based version control (including local workspaces in 
+   VS2012) changes to AssemblyInfo.cs will be picked up for check in.
+   
+   If you don't want every build to trigger a change for these files,
+   then reset the build and release numbers in the AfterBuild step.
+   
+   Note: You don't want to ignore these files completely, as you need 
+   to include them as part of the project (and once added changes will 
+   be detected).
+   
+   -->
+
+  <Target Name="ResetCSharpAssemblyInfoFile"
+        DependsOnTargets="TFSBuildFileVersion" >
+    <CreateProperty Value='$(VersionInfoFile)'>
+      <Output TaskParameter="Value" PropertyName="SourceAssemblyInfoFile" />
+    </CreateProperty>
+    <CreateProperty Value='$(SourceAssemblyInfoFile)'>
+      <Output TaskParameter="Value" PropertyName="DestinationAssemblyInfoFile" />
+    </CreateProperty>
+    <CreateProperty Value='"$(TFSMajorBuildNumber).$(TFSMinorBuildNumber).0.0"'>
+      <Output TaskParameter="Value" PropertyName="AssemblyFileVersion" />
+    </CreateProperty>
+    <CreateProperty Value='"$(TFSMajorBuildNumber).$(TFSMinorBuildNumber).0.0"'>
+      <Output TaskParameter="Value" PropertyName="AssemblyVersion" />
+    </CreateProperty>
+    <Exec Condition="Exists('$(DestinationAssemblyInfoFile)') and '$(TFSSetReadOnly)'=='true'" Command='attrib -R "$(DestinationAssemblyInfoFile)"' IgnoreExitCode='true' />
+    <Message Text="Reseting file '$(DestinationAssemblyInfoFile)' to file version $(AssemblyFileVersion)." />
+    <CreateProperty	Value='$([System.IO.File]::ReadAllText("$(SourceAssemblyInfoFile)"))'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="OriginalAssemblyInfo" />
+    </CreateProperty>
+    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Replace($(OriginalAssemblyInfo),"AssemblyFileVersion\s*\(.*?\)","AssemblyFileVersion($(AssemblyFileVersion))"))'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="FileVersionUpdatedInfo" />
+    </CreateProperty>
+    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Replace($(FileVersionUpdatedInfo),"AssemblyVersion\s*\(.*?\)","AssemblyVersion($(AssemblyVersion))"))'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="FullUpdatedInfo" />
+    </CreateProperty>
+    <WriteLinesToFile
+      File="$(DestinationAssemblyInfoFile)"
+      Lines='$(FullUpdatedInfo)'
+      Overwrite="true" />
+    <Exec Condition="'$(TFSSetReadOnly)'=='true'" Command='attrib +R "$(DestinationAssemblyInfoFile)"' />
+  </Target>
+
+  <!-- Writes to (or updates) a text file in the current project.
+       This would usually be an existing file that can then be copied
+       to the output directory (as content), e.g. so you can tell the
+       deployed version of web site files. -->
+  
+  <Target Name="WriteProjectTextAssemblyVersionFile"
+        DependsOnTargets="TFSBuildFileVersion">
+    <CreateProperty Value='$(MSBuildProjectDirectory)\Version.txt'>
+      <Output TaskParameter="Value" PropertyName="ProjectTextVersionFile" />
+    </CreateProperty>
+    <Exec Condition="Exists('$(ProjectTextVersionFile)') and '$(TFSSetReadOnly)'=='true'" Command='attrib -R "$(ProjectTextVersionFile)"' IgnoreExitCode='true' />
+    <Message Text="Updating file '$(ProjectTextVersionFile)' with file version $(TFSFullBuildVersionString)." />
+    <ItemGroup>
+      <TXTLines Include="$(TFSFullBuildVersionString)"/>
+    </ItemGroup>
+    <WriteLinesToFile Overwrite="true"
+                      File="$(ProjectTextVersionFile)"
+                      Lines="@(TXTLines)"/>
+    <Exec Condition="'$(TFSSetReadOnly)'=='true'" Command='attrib +R "$(ProjectTextVersionFile)"' />
+  </Target>
+
+</Project>

--- a/src/TFSBuildNumber.targets
+++ b/src/TFSBuildNumber.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- TFSBuildNumber.targets, Version 1.3 - August, 2014 -->
+  <!-- TFSBuildNumber.targets, Version 1.4 - May, 2015 -->
 
   <!-- Updates build numbers in projects based on the TFS build number.
   
@@ -18,6 +18,8 @@
          - If assembly info file needs to be Read Only (so that older TFS source
            control doesn't pick it up as a change) then can unset/set the
            read only flag on the file.
+         - Also updates AssemblyInformationalVersion, useful for NuGet 
+           packaging.
            
        To use:
        
@@ -50,6 +52,13 @@
           
        6. If your AssemblyInfo.cs file is usually read only, then you need to set
           the additional property <TFSSetReadOnly>true</TFSSetReadOnly> to handle this.
+          
+       7. For NuGet packaging support, add the following to AssemblyInfo.cs:
+       
+          [assembly: AssemblyInformationalVersion("1.0.0.0")]
+          
+          This will be replaced with the full version number from AssemblyFileVersion
+          (otherwise, NuGet uses AssemblyVersion, which only has major/minor numbers).
           
        NOTE: If you don't want to use GetMajorMinorFromCSharpAssemblyInfoFile,
        an alternative is to set the TFSMajorBuildNumber and TFSMinorBuildNumber
@@ -294,7 +303,12 @@
         TaskParameter="Value"
         PropertyName="FileVersionUpdatedInfo" />
     </CreateProperty>
-    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Replace($(FileVersionUpdatedInfo),"AssemblyVersion\s*\(.*?\)","AssemblyVersion($(AssemblyVersion))"))'>
+    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Replace($(FileVersionUpdatedInfo),"AssemblyInformationalVersion\s*\(.*?\)","AssemblyInformationalVersion($(AssemblyFileVersion))"))'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="InformationalVersionUpdatedInfo" />
+    </CreateProperty>
+    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Replace($(InformationalVersionUpdatedInfo),"AssemblyVersion\s*\(.*?\)","AssemblyVersion($(AssemblyVersion))"))'>
       <Output
         TaskParameter="Value"
         PropertyName="FullUpdatedInfo" />
@@ -346,7 +360,12 @@
         TaskParameter="Value"
         PropertyName="FileVersionUpdatedInfo" />
     </CreateProperty>
-    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Replace($(FileVersionUpdatedInfo),"AssemblyVersion\s*\(.*?\)","AssemblyVersion($(AssemblyVersion))"))'>
+    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Replace($(FileVersionUpdatedInfo),"AssemblyInformationalVersion\s*\(.*?\)","AssemblyInformationalVersion($(AssemblyFileVersion))"))'>
+      <Output
+        TaskParameter="Value"
+        PropertyName="InformationalVersionUpdatedInfo" />
+    </CreateProperty>
+    <CreateProperty Value='$([System.Text.RegularExpressions.Regex]::Replace($(InformationalVersionUpdatedInfo),"AssemblyVersion\s*\(.*?\)","AssemblyVersion($(AssemblyVersion))"))'>
       <Output
         TaskParameter="Value"
         PropertyName="FullUpdatedInfo" />


### PR DESCRIPTION
Add build target steps that update the version number in AssemblyInfo.cs, useful when built locally (but not needed if using something like TeamCity that adds version numbers for you).